### PR TITLE
♻️ (Dockerfile): improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,13 @@ RUN apt update -y && apt install curl -y \
     && curl -fsSL https://nodejs.org/dist/$version/node-$version-linux-x64.tar.gz -o node.tar.gz \
     && tar -xzf node.tar.gz && rm node.tar.gz
 
-RUN npm install -g @slidev/cli
-RUN npm install -g @slidev/theme-seriph
-RUN npm install -g slidev-theme-academic
-
-
-# Crea directory per slidev
-RUN mkdir -p /home/jovyan/slidev
-
-WORKDIR /home/jovyan/slidev
-
 USER jovyan
 
-CMD ["slidev", "dev"]
+# NOTE: in case of errors, could be added to .bashrc too !
+ENV PATH="~/.local/bin:$PATH"
+
+RUN npm config set prefix '~/.local/' && mkdir -p ~/.local/bin
+
+RUN npm install -g @slidev/cli && \
+    npm install -g @slidev/theme-seriph && \
+    npm install -g slidev-theme-academic

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/uninuvola/base:main
 
 USER root
 
-# Installa Node.js 18 e Slidev
+# Install Node.js 18 (with npm)
 ARG version=v18.20.2
 ENV NODE_DIR=/node-$version-linux-x64
 ENV PATH=$NODE_DIR/bin:$PATH
@@ -11,13 +11,17 @@ RUN apt update -y && apt install curl -y \
     && curl -fsSL https://nodejs.org/dist/$version/node-$version-linux-x64.tar.gz -o node.tar.gz \
     && tar -xzf node.tar.gz && rm node.tar.gz
 
+# Slidev will be installed in "/opt/slidev" by jovyan user
+# This let the users to install other packages via npm without sudo privileges
+# and this folder isn't overridden by docker bindmount
+RUN mkdir -p /opt/slidev/ && chown -R jovyan:users /opt/slidev/
+
 USER jovyan
 
-# NOTE: in case of errors, could be added to .bashrc too !
-ENV PATH="~/.local/bin:$PATH"
+ENV PATH="/opt/slidev/bin:$PATH"
 
-RUN npm config set prefix '~/.local/' && mkdir -p ~/.local/bin
-
-RUN npm install -g @slidev/cli && \
+# Install slidev
+RUN npm config set prefix '/opt/slidev' && \
+    npm install -g @slidev/cli && \
     npm install -g @slidev/theme-seriph && \
     npm install -g slidev-theme-academic


### PR DESCRIPTION
Provando la tua immagine ho riscontrato alcuni problemi che impedivano all'utente `jovyan` di eseguire correttamente `slidev`. Ho anche identificato alcune opportunità di ottimizzazione per ridurre le dimensioni dell'immagine risultante. 

In particolare, l'installazione di `slidev` come utente `root` causava problemi di autorizzazione per l'utente `jovyan`. Per risolvere questo problema, ho spostato l'installazione di `slidev` nella sezione dell'utente normale e l'ho accorpata in una singola direttiva `RUN` (riducendo così il numero di layer da 3 a 1). 

Inoltre, ho modificato l'installazione di `slidev` in modo che venga installato in `/opt/slidev`, garantendo così all'utente `jovyan` l'accesso alla cartella e evitandone la sovrascrittura quando il container viene avviato e il bindmound dei dati dell'utente viene effettuato. 